### PR TITLE
Use htmltools::htmlDependency() to load fabric.js

### DIFF
--- a/R/use_fabric.R
+++ b/R/use_fabric.R
@@ -5,14 +5,26 @@
 #' @export
 #'
 #' @description This function activates the javascript library fabricjs. You should put it at the beginning of your Rmd document or Shiny UI.
-#' Note that you'll need to be connected to the internet.
 #'
 
 
 
-use_fabric <- function(){
+use_fabric <- function() {
+  htmltools::tagList(
+    html_dependency_fabric()
+  )
+}
 
-
-  htmltools::tags$script(src = "https://cdnjs.cloudflare.com/ajax/libs/fabric.js/3.6.3/fabric.min.js")
-
+html_dependency_fabric <- function() {
+  htmltools::htmlDependency(
+    name = "fabric",
+    version = "3.6.3",
+    package = "fabricerin",
+    src = c(
+      file = "fabric",
+      href = "https://cdnjs.cloudflare.com/ajax/libs/fabric.js/3.6.3/"
+    ),
+    script = "fabric.min.js",
+    all_files = FALSE
+  )
 }

--- a/man/use_fabric.Rd
+++ b/man/use_fabric.Rd
@@ -11,5 +11,4 @@ called for the side effect of activating the fabricjs library
 }
 \description{
 This function activates the javascript library fabricjs. You should put it at the beginning of your Rmd document or Shiny UI.
-Note that you'll need to be connected to the internet.
 }


### PR DESCRIPTION
`htmltools::htmlDependency()` provides a number of advantages over loading
the `fabric.js` dependency via a `<script>` tag. The primary advantage is
that dependencies declared with `htmlDependency()` are loaded in the `<head>`
of the output page, so you can be confident that the dependency is available
by the time document content is rendered.

This PR changes `use_fabric()` to use an `htmlDependency()` for this reason.
I also added the minified JS file into the package so that users do not need
to be connected to the internet for the package functionality to work.

The second advantage to using an `htmlDependency()` is that it makes it
possible for you to simplify the process for your users so that they don't
need to call `use_fabric()` in order to use functions that depend on fabric.js.
Instead, if you attach `html_dependency_fabric()` to the tags created in other
functions, like `fabric_drawing()`, by including it in a `tagList()`, the
dependency will only be loaded once and will be included by default in the
final document.

```r
fabric_drawing <- function(...) {
  # set up code ...

  htmltools::tagList(
    # tags for fabric_drawing() function ...
    html_dependency_fabric()
  )
}
```

I didn't do this in this PR but wanted to point out this possibility.

A final advantage to using `htmlDependency()` is that dependencies are
only loaded once per document, even if _other packages_ load the same
dependency. In other words, users who call `fabric_drawing()` more than
once will only have `fabric.js` included one time in their output. You
should also consider using this approach for the jQuery and FileSaver
dependencies, e.g. in `fabric_drawing()`, because as currently implemented
they are loaded each time a user calls that function.